### PR TITLE
M4 T-050: Category icons via ACF (soft dep)

### DIFF
--- a/news-listing/readme.txt
+++ b/news-listing/readme.txt
@@ -25,6 +25,8 @@ For grid layout, pagination is automatically handled when used on pages and arch
 
 For carousel layout, items scroll horizontally with scroll-snap. Previous/Next buttons are included and keyboard arrows navigate one card at a time; touch swipe is supported by the browser.
 
+Category icons are an optional, soft dependency: if Advanced Custom Fields is active and a term field named category_icon (image URL) exists for the post categories, icons are shown. Otherwise, the plugin will attempt to read a category_icon URL from term meta; if none, icons are omitted.
+
 == Installation ==
 1. Upload the `news-listing` folder to `/wp-content/plugins/`.
 2. Activate the plugin.


### PR DESCRIPTION
This PR documents T-050 behavior.\n\nAcceptance:\n- [x] Attempts get_field('category_icon', 'category_'+term_id) if ACF exists; else tries get_term_meta(term_id, 'category_icon', true); else omit\n- [x] Images sanitized; alt = category name\n\nNotes:\n- Logic already exists in the shortcode renderer.\n- README updated with soft dependency and fallback behavior.\n\nPM_APPROVED: no