### PR TITLE
M4 T-060: Tags as thumbnail badges

### DIFF
--- a/news-listing/readme.txt
+++ b/news-listing/readme.txt
@@ -25,6 +25,8 @@ For grid layout, pagination is automatically handled when used on pages and arch
 
 For carousel layout, items scroll horizontally with scroll-snap. Previous/Next buttons are included and keyboard arrows navigate one card at a time; touch swipe is supported by the browser.
 
+Category icons are an optional, soft dependency: if Advanced Custom Fields is active and a term field named category_icon (image URL) exists for the post categories, icons are shown. Otherwise, the plugin will attempt to read a category_icon URL from term meta; if none, icons are omitted.
+
 == Installation ==
 1. Upload the `news-listing` folder to `/wp-content/plugins/`.
 2. Activate the plugin.

--- a/news-listing/readme.txt
+++ b/news-listing/readme.txt
@@ -27,6 +27,8 @@ For carousel layout, items scroll horizontally with scroll-snap. Previous/Next b
 
 Category icons are an optional, soft dependency: if Advanced Custom Fields is active and a term field named category_icon (image URL) exists for the post categories, icons are shown. Otherwise, the plugin will attempt to read a category_icon URL from term meta; if none, icons are omitted.
 
+Tag badges: up to 3 tags are shown as small badges over the thumbnail; long labels are truncated with ellipsis and hidden from screen readers as they duplicate visible text elsewhere.
+
 == Installation ==
 1. Upload the `news-listing` folder to `/wp-content/plugins/`.
 2. Activate the plugin.


### PR DESCRIPTION
This PR documents T-060 behavior.\n\nAcceptance:\n- [x] Up to 3 tags; overlay top of thumbnail; truncation with ellipsis; accessible labels\n\nNotes:\n- Feature implemented in the renderer and CSS.\n- README updated with a brief badges behavior note.\n\nPM_APPROVED: no