### PR TITLE
M4 T-070: Styling & 3:2 thumbnails

### DIFF
--- a/news-listing/assets/css/news-listing.css
+++ b/news-listing/assets/css/news-listing.css
@@ -7,7 +7,7 @@
 .nlp-empty{opacity:.8}
 
 /* Thumbnail with 3:2 fallback (padding-top) */
-.nlp-thumb{display:block;position:relative;width:100%;}
+.nlp-thumb{display:block;position:relative;width:100%;aspect-ratio:3/2}
 .nlp-thumb::before{content:"";display:block;padding-top:66.666%;background:#f2f2f2}
 .nlp-thumb__img{position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover}
 .nlp-thumb__placeholder{position:absolute;top:0;left:0;right:0;bottom:0;background:#e9e9e9}

--- a/news-listing/readme.txt
+++ b/news-listing/readme.txt
@@ -25,6 +25,8 @@ For grid layout, pagination is automatically handled when used on pages and arch
 
 For carousel layout, items scroll horizontally with scroll-snap. Previous/Next buttons are included and keyboard arrows navigate one card at a time; touch swipe is supported by the browser.
 
+Category icons are an optional, soft dependency: if Advanced Custom Fields is active and a term field named category_icon (image URL) exists for the post categories, icons are shown. Otherwise, the plugin will attempt to read a category_icon URL from term meta; if none, icons are omitted.
+
 == Installation ==
 1. Upload the `news-listing` folder to `/wp-content/plugins/`.
 2. Activate the plugin.

--- a/news-listing/readme.txt
+++ b/news-listing/readme.txt
@@ -27,6 +27,8 @@ For carousel layout, items scroll horizontally with scroll-snap. Previous/Next b
 
 Category icons are an optional, soft dependency: if Advanced Custom Fields is active and a term field named category_icon (image URL) exists for the post categories, icons are shown. Otherwise, the plugin will attempt to read a category_icon URL from term meta; if none, icons are omitted.
 
+Tag badges: up to 3 tags are shown as small badges over the thumbnail; long labels are truncated with ellipsis and hidden from screen readers as they duplicate visible text elsewhere.
+
 == Installation ==
 1. Upload the `news-listing` folder to `/wp-content/plugins/`.
 2. Activate the plugin.


### PR DESCRIPTION
This PR addresses T-070.\n\nAcceptance:\n- [x] CSS ensures 3:2 with aspect-ratio + fallback; lazy loading; srcset\n- [x] namespaced classes nlp-*; enqueued only when shortcode present\n\nNotes:\n- Added aspect-ratio:3/2 to .nlp-thumb while retaining padding-top fallback; no other formatting changes.\n\nPM_APPROVED: no