### PR TITLE
M5 T-080: Accessibility & i18n (.pot)

### DIFF
--- a/news-listing/languages/news-listing.pot
+++ b/news-listing/languages/news-listing.pot
@@ -1,0 +1,30 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: News Listing Shortcode 0.1.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-28 00:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: manual\n"
+"X-Domain: news-listing\n"
+
+#: news-listing/includes/Shortcode.php
+msgid "Previous"
+msgstr ""
+
+#: news-listing/includes/Shortcode.php
+msgid "Next"
+msgstr ""
+
+#: news-listing/includes/Shortcode.php
+msgid "No posts found."
+msgstr ""
+
+#: news-listing/includes/Shortcode.php
+msgid "News pagination"
+msgstr "" 


### PR DESCRIPTION
This PR adds the .pot file for the text domain.\n\nAcceptance:\n- [x] .pot generated; text domain \n- [x] Pagination and controls use aria-labels; already implemented.\n\nNotes:\n- .pot includes: Previous, Next, No posts found., News pagination.\n\nPM_APPROVED: no