### PR TITLE
M6 T-112: Fix grid pagination layout and arrow styles

### DIFF
--- a/news-listing/assets/css/news-listing.css
+++ b/news-listing/assets/css/news-listing.css
@@ -106,6 +106,28 @@
   color: #fff;
   border-color: #222;
 }
+/* T-112: horizontal list and simplified prev/next */
+.nlp-pagination ul {
+  display: inline-flex;
+  gap: 6px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.nlp-pagination li {
+  display: inline;
+}
+.nlp-pagination .prev,
+.nlp-pagination .next {
+  border: 0;
+  background: transparent;
+  padding: 6px 10px;
+}
+.nlp-pagination a:focus,
+.nlp-pagination span:focus {
+  outline: 2px solid #3b82f6;
+  outline-offset: 2px;
+}
 
 /* Carousel base (scroll-snap) */
 .nlp-wrapper[data-layout="carousel"] {

--- a/news-listing/assets/css/news-listing.css
+++ b/news-listing/assets/css/news-listing.css
@@ -94,10 +94,11 @@
 /* Pagination */
 .nlp-pagination {
   margin-top: 16px;
+  text-align: center;
 }
 .nlp-pagination .page-numbers {
   padding: 6px 10px;
-  border: 1px solid #ddd;
+  border: 0;
   margin-right: 6px;
   text-decoration: none;
 }

--- a/news-listing/includes/Shortcode.php
+++ b/news-listing/includes/Shortcode.php
@@ -276,8 +276,8 @@ class NLS_Shortcode {
                 'current'   => max( 1, $paged ),
                 'total'     => (int) $q->max_num_pages,
                 'type'      => 'list',
-                'prev_text' => '&#10094;',
-                'next_text' => '&#10095;',
+                'prev_text' => '&lt;',
+                'next_text' => '&gt;',
             ) );
             if ( $links ) {
                 echo '<nav class="nlp-pagination" aria-label="' . esc_attr__( 'News pagination', 'news-listing' ) . '">';


### PR DESCRIPTION
Implements T-112.\n\nAcceptance:\n- [x] Pagination list items render horizontally (inline/inline-flex).\n- [x] Prev/Next show as "<" and ">" and have no border box; numbered pages keep minimal styling.\n- [x]  present on the nav wrapper; focusable controls show visible focus outline.\n- [x] Verified styles in CSS; PHP emits correct arrow text.\n\nFiles:\n- news-listing/assets/css/news-listing.css\n- news-listing/includes/Shortcode.php\n\nPM_APPROVED: no