### PR TITLE
M6 T-113: Overlay category icons on thumbnail (bottom-right stack)

### DIFF
--- a/news-listing/assets/css/news-listing.css
+++ b/news-listing/assets/css/news-listing.css
@@ -63,6 +63,7 @@
   display: flex;
   gap: 6px;
   flex-wrap: wrap;
+  z-index: 2;
 }
 .nlp-badge {
   background: rgba(0, 0, 0, 0.75);
@@ -82,13 +83,22 @@
   display: flex;
   gap: 8px;
   align-items: center;
-  margin-top: 6px;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
 }
 .nlp-icon {
   width: 20px;
   height: 20px;
   display: inline-block;
+}
+/* Overlay icons inside thumbnail, bottom-right */
+.nlp-thumb {
+  position: relative;
+}
+.nlp-thumb .nlp-icons {
+  position: absolute;
+  right: 8px;
+  bottom: 8px;
+  z-index: 2;
 }
 
 /* Pagination */

--- a/news-listing/assets/css/news-listing.css
+++ b/news-listing/assets/css/news-listing.css
@@ -86,9 +86,11 @@
   flex-wrap: nowrap;
 }
 .nlp-icon {
-  width: 20px;
-  height: 20px;
+  width: 32px;
+  height: 32px;
   display: inline-block;
+  border: 0.5px solid #fff;
+  box-shadow: 0 0 1px 1px rgba(0, 0, 0, 0.2);
 }
 /* Overlay icons inside thumbnail, bottom-right */
 .nlp-thumb {
@@ -96,8 +98,8 @@
 }
 .nlp-thumb .nlp-icons {
   position: absolute;
-  right: 8px;
-  bottom: 8px;
+  right: 4px;
+  bottom: 4px;
   z-index: 2;
 }
 

--- a/news-listing/includes/Shortcode.php
+++ b/news-listing/includes/Shortcode.php
@@ -242,6 +242,7 @@ class NLS_Shortcode {
                 echo '<a class="nlp-thumb" href="' . esc_url( get_permalink( $post_id ) ) . '">';
                 echo $thumb_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- from core helper already escaped.
                 echo $badges_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- constructed with esc_html.
+                echo $icons_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- sanitized URLs and attrs.
                 echo '</a>';
 
                 echo '<h3 class="nlp-title"><a href="' . esc_url( get_permalink( $post_id ) ) . '">' . esc_html( get_the_title( $post_id ) ) . '</a></h3>';
@@ -249,7 +250,8 @@ class NLS_Shortcode {
                 $excerpt = wp_trim_words( get_the_excerpt( $post_id ), 22, '&hellip;' );
                 echo '<div class="nlp-excerpt">' . wp_kses_post( $excerpt ) . '</div>';
 
-                echo $icons_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                // Removed separate icons output to overlay them within thumbnail.
+                // echo $icons_html;
 
                 echo '</article>';
             }


### PR DESCRIPTION
Implements T-113.\n\nAcceptance:\n- [x] Category icons render inside the thumbnail, bottom-right, stacked horizontally (6–8px gap).\n- [x] No layout shift; appear above image; do not obscure tag badges.\n- [x] Alt equals category name; omit cleanly if none.\n- [x] Works with 1–4 icons.\n\nFiles:\n- news-listing/includes/Shortcode.php\n- news-listing/assets/css/news-listing.css\n\nPM_APPROVED: no