### PR TITLE
M6 T-114: Increase grid/carousel gaps to 32px

### DIFF
--- a/news-listing/assets/css/news-listing.css
+++ b/news-listing/assets/css/news-listing.css
@@ -4,7 +4,7 @@
 }
 .nlp-grid {
   display: grid;
-  grid-gap: 16px;
+  grid-gap: 32px;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 }
 .nlp-item {
@@ -152,7 +152,7 @@
   display: flex;
   overflow-x: auto;
   scroll-snap-type: x mandatory;
-  gap: 16px;
+  gap: 32px;
   outline: 0;
   padding: 4px;
 }
@@ -166,7 +166,7 @@
     .nlp-carousel[style*="--nlp-visible"]
     .nlp-item {
     /* Each card width = (container - total gaps) / N */
-    width: calc((100% - (var(--nlp-visible) - 1) * 16px) / var(--nlp-visible));
+    width: calc((100% - (var(--nlp-visible) - 1) * 32px) / var(--nlp-visible));
     min-width: 0;
     flex: 0 0 auto;
   }


### PR DESCRIPTION
Implements T-114.\n\nAcceptance:\n- [x] Grid gutter between items is exactly 32px at all breakpoints.\n- [x] Carousel inter-card gap is 32px; step calculation uses card width + computed gap.\n- [x] Visual check confirms consistent spacing.\n\nFiles:\n- news-listing/assets/css/news-listing.css\n\nPM_APPROVED: no